### PR TITLE
PushFixed function for static dataset size

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ func main() {
   // PushFixed method will keep the size of the Data vector constant.
   // Oldest data points will be evicted as points are added.
   // WARNING: Mixing Push() and PushFixed() will result in failure!
-	anom2, _ := anomalyzer.NewAnomalyzer(conf, data)
+  anom2, _ := anomalyzer.NewAnomalyzer(conf, data)
   prob2, _ := anom2.PushFixed(8.0)
   // returns an error as second value if the array size changed unexpectantly 
 	fmt.Println("Anomalous Probability:", prob2)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To capture seasonality, the bootstrap ks test should consider an active window l
 
 ### Fence
 
-The fence test can be configured to use custom `UpperBound` and `LowerBound` values for the fences.  If no lower bound is desired, set the value of `LowerBound` to `anomalyzer.NA`.
+The fence test can be configured to use custom `UpperBound` and `LowerBound` values for the fences.  If no lower bound is desired, set the value of `LowerBound` to the const variable: `anomalyzer.NA`.
 
 ### Diff & Rank
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ func main() {
 	// by a call to the Eval method.
 	prob := anom.Push(8.0)
 	fmt.Println("Anomalous Probability:", prob)
+
+  // PushFixed method will keep the size of the Data vector constant.
+  // Oldest data points will be evicted as points are added.
+  // WARNING: Mixing Push() and PushFixed() will result in failure!
+	anom2, _ := anomalyzer.NewAnomalyzer(conf, data)
+  prob2, _ := anom2.PushFixed(8.0)
+  // returns an error as second value if the array size changed unexpectantly 
+	fmt.Println("Anomalous Probability:", prob2)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ func main() {
 
   // PushFixed method will keep the size of the Data vector constant.
   // Oldest data points will be evicted as points are added.
-  // WARNING: Mixing Push() and PushFixed() will result in failure!
   anom2, _ := anomalyzer.NewAnomalyzer(conf, data)
-  prob2, _ := anom2.PushFixed(8.0)
-  // returns an error as second value if the array size changed unexpectantly 
+	prob2, _ := anom2.PushFixed(8.0)
+	// returns an error as second value if the array size changed unexpectantly
 	fmt.Println("Anomalous Probability:", prob2)
 }
 ```

--- a/anomalyze.go
+++ b/anomalyze.go
@@ -139,7 +139,6 @@ func (a *Anomalyzer) Push(x float64) float64 {
 	return a.Eval()
 }
 
-// WARNING: Mixing Push() and PushFixed() will result in failure!
 func (a *Anomalyzer) PushFixed(x float64) (float64, error) {
 	// Add data to fixed size array which will not grow
 	err := a.Data.PushFixed(x)

--- a/anomalyze.go
+++ b/anomalyze.go
@@ -139,12 +139,15 @@ func (a *Anomalyzer) Push(x float64) float64 {
 	return a.Eval()
 }
 
-func (a *Anomalyzer) PushFixed(x float64) float64 {
+func (a *Anomalyzer) PushFixed(x float64) (float64, error) {
 	// Add data to fixed size array which will not grow
-	a.Data.PushFixed(x)
+	err := a.Data.PushFixed(x)
+	if err != nil {
+		return NA, err
+	}
 
 	// evaluate the anomalous probability
-	return a.Eval()
+	return a.Eval(), nil
 }
 
 // Return the weighted average of all statistical tests

--- a/anomalyze.go
+++ b/anomalyze.go
@@ -139,6 +139,14 @@ func (a *Anomalyzer) Push(x float64) float64 {
 	return a.Eval()
 }
 
+func (a *Anomalyzer) PushFixed(x float64) float64 {
+	// Add data to fixed size array which will not grow
+	a.Data.PushFixed(x)
+
+	// evaluate the anomalous probability
+	return a.Eval()
+}
+
 // Return the weighted average of all statistical tests
 // for anomaly detection, which yields the probability that
 // the currently observed behavior is anomalous.

--- a/anomalyze.go
+++ b/anomalyze.go
@@ -139,6 +139,7 @@ func (a *Anomalyzer) Push(x float64) float64 {
 	return a.Eval()
 }
 
+// WARNING: Mixing Push() and PushFixed() will result in failure!
 func (a *Anomalyzer) PushFixed(x float64) (float64, error) {
 	// Add data to fixed size array which will not grow
 	err := a.Data.PushFixed(x)

--- a/anomalyze_test.go
+++ b/anomalyze_test.go
@@ -61,10 +61,11 @@ func TestAnomalyzerPushFixed(t *testing.T) {
 	anomalyzer, err := NewAnomalyzer(conf, data)
 	assert.Equal(t, nil, err, "Error initializing new anomalyzer")
 
-	prob := anomalyzer.PushFixed(8.0)
-	prob = anomalyzer.PushFixed(10.0)
-	prob = anomalyzer.PushFixed(8.0)
-	prob = anomalyzer.PushFixed(9.0)
+	prob, err := anomalyzer.PushFixed(8.0)
+	prob, err = anomalyzer.PushFixed(10.0)
+	prob, err = anomalyzer.PushFixed(8.0)
+	prob, err = anomalyzer.PushFixed(9.0)
+	assert.Equal(t, err, nil, "There was an error with array size")
 	assert.Tf(t, prob > 0.5, "Anomalyzer returned a probability that was too small")
 	assert.Equal(t, len(anomalyzer.Data), 6, "Array size did not stay at original size")
 }

--- a/anomalyze_test.go
+++ b/anomalyze_test.go
@@ -45,6 +45,30 @@ func TestAnomalyzer(t *testing.T) {
 	assert.Tf(t, prob > 0.5, "Anomalyzer returned a probability that was too small")
 }
 
+func TestAnomalyzerPushFixed(t *testing.T) {
+	conf := &AnomalyzerConf{
+		Sensitivity: 0.1,
+		UpperBound:  5,
+		LowerBound:  0,
+		ActiveSize:  1,
+		NSeasons:    4,
+		Methods:     []string{"cdf", "fence", "highrank", "lowrank", "magnitude"},
+	}
+
+	// initialize with empty data or an actual slice of floats
+	data := []float64{0.1, 2.05, 1.5, 2.5, 2.6, 2.55}
+
+	anomalyzer, err := NewAnomalyzer(conf, data)
+	assert.Equal(t, nil, err, "Error initializing new anomalyzer")
+
+	prob := anomalyzer.PushFixed(8.0)
+	prob = anomalyzer.PushFixed(10.0)
+	prob = anomalyzer.PushFixed(8.0)
+	prob = anomalyzer.PushFixed(9.0)
+	assert.Tf(t, prob > 0.5, "Anomalyzer returned a probability that was too small")
+	assert.Equal(t, len(anomalyzer.Data), 6, "Array size did not stay at original size")
+}
+
 func Example() {
 	conf := &AnomalyzerConf{
 		Sensitivity: 0.1,

--- a/anomalyze_test.go
+++ b/anomalyze_test.go
@@ -70,6 +70,33 @@ func TestAnomalyzerPushFixed(t *testing.T) {
 	assert.Equal(t, len(anomalyzer.Data), 6, "Array size did not stay at original size")
 }
 
+func TestAnomalyzerPushMixed(t *testing.T) {
+	conf := &AnomalyzerConf{
+		Sensitivity: 0.1,
+		UpperBound:  5,
+		LowerBound:  0,
+		ActiveSize:  1,
+		NSeasons:    4,
+		Methods:     []string{"cdf", "fence", "highrank", "lowrank", "magnitude"},
+	}
+
+	// initialize with empty data or an actual slice of floats
+	data := []float64{0.1, 2.05, 1.5, 2.5, 2.6, 2.55}
+
+	anomalyzer, err := NewAnomalyzer(conf, data)
+	assert.Equal(t, nil, err, "Error initializing new anomalyzer")
+
+	prob, err := anomalyzer.PushFixed(8.0)
+	prob = anomalyzer.Push(10.0)
+	prob, err = anomalyzer.PushFixed(8.0)
+	prob = anomalyzer.Push(9.0)
+	assert.Equal(t, err, nil, "There was an error with mixing array extension")
+	assert.Tf(t, prob > 0.5, "Anomalyzer returned a probability that was too small")
+	assert.Equal(t, len(anomalyzer.Data), 8, "Array size Push* functions failed to grow Data to expected size")
+	assert.Equal(t, anomalyzer.Data[7], 9.0)
+	assert.Equal(t, anomalyzer.Data[0], 1.5, "Two values were appended, two values were popped from the array. 3rd original element should be tail.")
+}
+
 func Example() {
 	conf := &AnomalyzerConf{
 		Sensitivity: 0.1,


### PR DESCRIPTION
Instead of Push simply appending data points to ever expanding Go slices; this change
will utilize GoVector's PushFixed function to keep the array size constant as data points 
are added by dropping the oldest event. The goal is to keep memory allocations for long 
running processes constantly evaluating anomalies consistent.

eg

```
anomalyzer.Data: [ 1.0, 2.0, 3.0] 
err := anomalyzer.PushFixed(5.0)
anomalyzer.Data: [2.0, 3.0, 5.0]
```

Mixing `Push` and `FixedPush` for a anomalyzer data set will result in failures. The problem stems from the `len` of an array changing, but the `cap` not also being updated. There might be a easy fix another change will need to be made to GoVector.
